### PR TITLE
Users pagination

### DIFF
--- a/src/controllers/patient/getPatientsController.js
+++ b/src/controllers/patient/getPatientsController.js
@@ -2,7 +2,6 @@ import getPatientsHandler from "../../handlers/patient/getPatientsHandler.js";
 
 const getPatientsController = async (req, res) => {
   const { limit, page, filter } = req.query;
-  console.log(limit, page);
   try {
     const users = await getPatientsHandler({ limit, page, filter });
     return res.status(200).json(users);

--- a/src/controllers/patient/getPatientsController.js
+++ b/src/controllers/patient/getPatientsController.js
@@ -1,12 +1,14 @@
 import getPatientsHandler from "../../handlers/patient/getPatientsHandler.js";
 
 const getPatientsController = async (req, res) => {
-    try {
-        const users = await getPatientsHandler();
-        return res.status(200).json(users);
-    } catch (error) {
-        return res.status(500).json({error: error.message});
-    }
+  const { limit, page, filter } = req.query;
+  console.log(limit, page);
+  try {
+    const users = await getPatientsHandler({ limit, page, filter });
+    return res.status(200).json(users);
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
 };
 
 export default getPatientsController;

--- a/src/controllers/patient/getPatientsController.js
+++ b/src/controllers/patient/getPatientsController.js
@@ -1,9 +1,9 @@
 import getPatientsHandler from "../../handlers/patient/getPatientsHandler.js";
 
 const getPatientsController = async (req, res) => {
-  const { limit, page, filter } = req.query;
+  const { limit, page } = req.query;
   try {
-    const users = await getPatientsHandler({ limit, page, filter });
+    const users = await getPatientsHandler({ limit, page });
     return res.status(200).json(users);
   } catch (error) {
     return res.status(500).json({ error: error.message });

--- a/src/controllers/physician/getAllPhysiciansController.js
+++ b/src/controllers/physician/getAllPhysiciansController.js
@@ -1,14 +1,13 @@
 import getAllPhysiciansHandler from "../../handlers/physicianHandlers/getAllPhysiciansHandler.js";
 
-
 const getAllPhysiciansController = async (req, res) => {
-    try {
-        const allPhysicians = await getAllPhysiciansHandler()
-        res.status(200).json(allPhysicians);
-
-    } catch (error) {
-        return res.status(500).json({error: error.message});
-    }
+  const { page, limit } = req.query;
+  try {
+    const allPhysicians = await getAllPhysiciansHandler({ page, limit });
+    res.status(200).json(allPhysicians);
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
 };
 
 export default getAllPhysiciansController;

--- a/src/controllers/physician/getAllPhysiciansController.js
+++ b/src/controllers/physician/getAllPhysiciansController.js
@@ -2,6 +2,7 @@ import getAllPhysiciansHandler from "../../handlers/physicianHandlers/getAllPhys
 
 const getAllPhysiciansController = async (req, res) => {
   const { page, limit } = req.query;
+
   try {
     const allPhysicians = await getAllPhysiciansHandler({ page, limit });
     res.status(200).json(allPhysicians);

--- a/src/handlers/Pagination/paginationUsersHandler.js
+++ b/src/handlers/Pagination/paginationUsersHandler.js
@@ -1,0 +1,29 @@
+import models from "../../databaseConfig";
+
+const paginationUsersHandler = async ({ page, limit, queryOptions }) => {
+  
+    limit = parseInt(limit);
+    page = parseInt(page);
+
+    try {
+    const offset = (page - 1) * limit;
+    queryOptions.limit = limit;
+    queryOptions.offset = offset;
+
+    const { count, row: user } = await models.User.findAndCountAll(
+      queryOptions
+    );
+    const totalPages = Math.ceil(count / limit);
+
+    return {
+      totalItems: count,
+      totalPages: totalPages,
+      currentPage: page,
+      user: user,
+    };
+  } catch (error) {
+    throw new Error("Error loading pagination: " + error.message);
+  }
+};
+
+export default paginationUsersHandler;

--- a/src/handlers/Pagination/paginationUsersHandler.js
+++ b/src/handlers/Pagination/paginationUsersHandler.js
@@ -1,10 +1,17 @@
 import models from "../../databaseConfig.js";
 
 const paginationUsersHandler = async ({ page, limit, queryOptions }) => {
-  limit = parseInt(limit);
-  page = parseInt(page);
-
   try {
+    if ((limit && isNaN(parseInt(limit))) || (page && isNaN(parseInt(page)))) {
+      throw new Error("Limit and page must be valid numbers");
+    }
+    if (!limit || !page) {
+      throw new Error("Limit and page are needed");
+    }
+
+    limit = parseInt(limit);
+    page = parseInt(page);
+
     const offset = (page - 1) * limit;
     queryOptions.limit = limit;
     queryOptions.offset = offset;
@@ -15,7 +22,7 @@ const paginationUsersHandler = async ({ page, limit, queryOptions }) => {
     const totalPages = Math.ceil(count / limit);
 
     return {
-      totalItems: count,
+      totalUsers: count,
       totalPages: totalPages,
       currentPage: page,
       user: user,

--- a/src/handlers/Pagination/paginationUsersHandler.js
+++ b/src/handlers/Pagination/paginationUsersHandler.js
@@ -1,16 +1,15 @@
-import models from "../../databaseConfig";
+import models from "../../databaseConfig.js";
 
 const paginationUsersHandler = async ({ page, limit, queryOptions }) => {
-  
-    limit = parseInt(limit);
-    page = parseInt(page);
+  limit = parseInt(limit);
+  page = parseInt(page);
 
-    try {
+  try {
     const offset = (page - 1) * limit;
     queryOptions.limit = limit;
     queryOptions.offset = offset;
 
-    const { count, row: user } = await models.User.findAndCountAll(
+    const { count, rows: user } = await models.User.findAndCountAll(
       queryOptions
     );
     const totalPages = Math.ceil(count / limit);

--- a/src/handlers/patient/getPatientsHandler.js
+++ b/src/handlers/patient/getPatientsHandler.js
@@ -1,6 +1,6 @@
 import models from "../../databaseConfig.js";
 
-const getPatientsHandler = async ({ limit, page, filter }) => {
+const getPatientsHandler = async ({ limit, page }) => {
   try {
     //Type of role selection
     const queryOptions = {

--- a/src/handlers/patient/getPatientsHandler.js
+++ b/src/handlers/patient/getPatientsHandler.js
@@ -2,6 +2,7 @@ import models from "../../databaseConfig.js";
 
 const getPatientsHandler = async ({ limit, page, filter }) => {
   try {
+    //check if pagination was asked
     if (!limit || !page) {
       const getPatients = await models.User.findAll({
         where: {
@@ -13,6 +14,7 @@ const getPatientsHandler = async ({ limit, page, filter }) => {
       });
       return getPatients;
     } else {
+      //Pagination logic
       const offset = (page - 1) * limit;
       const { count, rows: patients } = await models.User.findAndCountAll({
         limit,

--- a/src/handlers/patient/getPatientsHandler.js
+++ b/src/handlers/patient/getPatientsHandler.js
@@ -12,7 +12,7 @@ const getPatientsHandler = async ({ limit, page }) => {
       },
     };
 
-    if (!limit || !page) {
+    if (!limit && !page) {
       // Without pagination
       const getPatients = await models.User.findAll(queryOptions);
       return getPatients;

--- a/src/handlers/patient/getPatientsHandler.js
+++ b/src/handlers/patient/getPatientsHandler.js
@@ -1,32 +1,35 @@
 import models from "../../databaseConfig.js";
 
-const getPatientsHandler = async ({ limit, page }) => {
+const getPatientsHandler = async ({ limit, page, filter }) => {
   try {
-    //check if pagination was asked
+    //Type of role selection
+    const queryOptions = {
+      where: {
+        role: 3,
+      },
+      attributes: {
+        exclude: ["password", "cellphone", "email"],
+      },
+    };
+
     if (!limit || !page) {
-      const getPatients = await models.User.findAll({
-        where: {
-          role: 3,
-        },
-        attributes: {
-          exclude: ["password", "cellphone", "email"],
-        },
-      });
+      // Without pagination
+      const getPatients = await models.User.findAll(queryOptions);
       return getPatients;
     } else {
-      //Pagination logic
+      // Pagination Logic
       const offset = (page - 1) * limit;
-      const { count, rows: patients } = await models.User.findAndCountAll({
-        limit,
-        offset,
-      });
+      queryOptions.limit = limit;
+      queryOptions.offset = offset;
+
+      const { count, rows: patients } = await models.User.findAndCountAll(queryOptions);
       const totalPages = Math.ceil(count / limit);
 
       return {
         totalItems: count,
-        totalPages,
+        totalPages: totalPages,
         currentPage: page,
-        patients,
+        patients: patients,
       };
     }
   } catch (error) {

--- a/src/handlers/patient/getPatientsHandler.js
+++ b/src/handlers/patient/getPatientsHandler.js
@@ -1,6 +1,6 @@
 import models from "../../databaseConfig.js";
 
-const getPatientsHandler = async ({ limit, page, filter }) => {
+const getPatientsHandler = async ({ limit, page }) => {
   try {
     //check if pagination was asked
     if (!limit || !page) {

--- a/src/handlers/patient/getPatientsHandler.js
+++ b/src/handlers/patient/getPatientsHandler.js
@@ -1,16 +1,32 @@
-import models from '../../databaseConfig.js'
+import models from "../../databaseConfig.js";
 
-const getPatientsHandler = async () => {
+const getPatientsHandler = async ({ limit, page, filter }) => {
   try {
-    const getPatients = await models.User.findAll({
-      where:{
-        role:3
-      },
-      attributes: {
-        exclude: ['password','cellphone', 'email']
-      }
-    });
-    return getPatients;
+    if (!limit || !page) {
+      const getPatients = await models.User.findAll({
+        where: {
+          role: 3,
+        },
+        attributes: {
+          exclude: ["password", "cellphone", "email"],
+        },
+      });
+      return getPatients;
+    } else {
+      const offset = (page - 1) * limit;
+      const { count, rows: patients } = await models.User.findAndCountAll({
+        limit,
+        offset,
+      });
+      const totalPages = Math.ceil(count / limit);
+
+      return {
+        totalItems: count,
+        totalPages,
+        currentPage: page,
+        patients,
+      };
+    }
   } catch (error) {
     throw new Error("Error loading patients: " + error.message);
   }

--- a/src/handlers/patient/getPatientsHandler.js
+++ b/src/handlers/patient/getPatientsHandler.js
@@ -1,4 +1,5 @@
 import models from "../../databaseConfig.js";
+import paginationUsersHandler from "../Pagination/paginationUsersHandler.js";
 
 const getPatientsHandler = async ({ limit, page }) => {
   try {
@@ -18,19 +19,7 @@ const getPatientsHandler = async ({ limit, page }) => {
       return getPatients;
     } else {
       // Pagination Logic
-      const offset = (page - 1) * limit;
-      queryOptions.limit = limit;
-      queryOptions.offset = offset;
-
-      const { count, rows: patients } = await models.User.findAndCountAll(queryOptions);
-      const totalPages = Math.ceil(count / limit);
-
-      return {
-        totalItems: count,
-        totalPages: totalPages,
-        currentPage: page,
-        patients: patients,
-      };
+      return paginationUsersHandler({ page, limit, queryOptions });
     }
   } catch (error) {
     throw new Error("Error loading patients: " + error.message);

--- a/src/handlers/physicianHandlers/getAllPhysiciansHandler.js
+++ b/src/handlers/physicianHandlers/getAllPhysiciansHandler.js
@@ -1,48 +1,65 @@
-import {
-    CatMedicalSpecialty,
-    CatRole,
-    PhysicianDetails,
-    PhysicianSpecialty,
-    User
-} from '../../databaseConfig.js'
+import models, {
+  CatMedicalSpecialty,
+  CatRole,
+  PhysicianDetails,
+  PhysicianSpecialty,
+  User,
+} from "../../databaseConfig.js";
 
+const getAllPhysiciansHandler = async ({ page, limit }) => {
+  try {
+    //Specifications for the role selected
+    const queryOptions = {
+      attributes: ["id", "name", "lastname", "email", "cellphone", "avatar"],
+      include: [
+        {
+          model: PhysicianSpecialty,
+          as: "physicianSpecialties",
+          attributes: ["id"],
+          include: {
+            model: CatMedicalSpecialty,
+            as: "specialty",
+            attributes: ["name"],
+          },
+        },
+        {
+          model: PhysicianDetails,
+          as: "physicianDetails",
+        },
+        {
+          model: CatRole,
+          as: "userRole",
+          where: {
+            roleName: "Médico",
+          },
+        },
+      ],
+    };
+    if (!limit && !page) {
+      //Without pagination
+      const allPhysicians = await User.findAll(queryOptions);
+      return allPhysicians;
+    } else {
+      //Pagination logic
+      const offset = (page - 1) * limit;
+      queryOptions.limit = limit;
+      queryOptions.offset = offset;
 
-const getAllPhysiciansHandler = async () => {
-    try {
-        const allPhysicians = await User.findAll(
-            {
-                attributes: ['id', 'name', 'lastname', "email", "cellphone", "avatar"],
-                include: [
-                    {
-                        model: PhysicianSpecialty,
-                        as: 'physicianSpecialties',
-                        attributes: ['id'],
-                        include: {
-                            model: CatMedicalSpecialty,
-                            as: 'specialty',
-                            attributes: ['name']
-                        }
-                    },
-                    {
-                        model: PhysicianDetails,
-                        as: 'physicianDetails'
-                    },
-                    {
-                        model: CatRole,
-                        as: 'userRole',
-                        where: {
-                            roleName: 'Médico'
-                        }
-                    }
-                ]
-            }
-        );
+      const { count, rows: physicians } = await models.User.findAndCountAll(
+        queryOptions
+      );
+      const totalPages = Math.ceil(count / limit);
 
-        return allPhysicians;
-
-    } catch (error) {
-        throw new Error("Error loading physicians: " + error.message);
+      return {
+        totalItems: count,
+        totalPages: totalPages,
+        currentPage: page,
+        physicians: physicians,
+      };
     }
+  } catch (error) {
+    throw new Error("Error loading physicians: " + error.message);
+  }
 };
 
 export default getAllPhysiciansHandler;

--- a/src/handlers/physicianHandlers/getAllPhysiciansHandler.js
+++ b/src/handlers/physicianHandlers/getAllPhysiciansHandler.js
@@ -5,6 +5,7 @@ import models, {
   PhysicianSpecialty,
   User,
 } from "../../databaseConfig.js";
+import paginationUsersHandler from "../Pagination/paginationUsersHandler.js";
 
 const getAllPhysiciansHandler = async ({ page, limit }) => {
   try {
@@ -40,22 +41,8 @@ const getAllPhysiciansHandler = async ({ page, limit }) => {
       const allPhysicians = await User.findAll(queryOptions);
       return allPhysicians;
     } else {
-      //Pagination logic
-      const offset = (page - 1) * limit;
-      queryOptions.limit = limit;
-      queryOptions.offset = offset;
-
-      const { count, rows: physicians } = await models.User.findAndCountAll(
-        queryOptions
-      );
-      const totalPages = Math.ceil(count / limit);
-
-      return {
-        totalItems: count,
-        totalPages: totalPages,
-        currentPage: page,
-        physicians: physicians,
-      };
+      //Pagination Logic
+      return paginationUsersHandler();
     }
   } catch (error) {
     throw new Error("Error loading physicians: " + error.message);

--- a/src/handlers/physicianHandlers/getAllPhysiciansHandler.js
+++ b/src/handlers/physicianHandlers/getAllPhysiciansHandler.js
@@ -42,7 +42,7 @@ const getAllPhysiciansHandler = async ({ page, limit }) => {
       return allPhysicians;
     } else {
       //Pagination Logic
-      return paginationUsersHandler();
+      return paginationUsersHandler({ page, limit, queryOptions });
     }
   } catch (error) {
     throw new Error("Error loading physicians: " + error.message);


### PR DESCRIPTION
**Pagination Use:**

It uses the same route to get all users (Physicians or Patients).

Data must be sent via query parameters.
_Example:_ http://localhost:5000/api/patients?page=1&limit=10

- Page: The value to select the page you need information from.
- Limit: The value to determine how many users you want per page.

**Return:**

The pagination route returns an object with 4 key-value pairs:

- totalUsers: The total number of users (number).
- totalPages: The number of pages needed to show all users.
- currentPage: Indicates the page the results belong to.
- users: An array of users selected based on the queryOptions described in the handlers where pagination is needed.